### PR TITLE
Send ZFS properties along with snapshots

### DIFF
--- a/zettarepl/transport/ssh_netcat_helper.py
+++ b/zettarepl/transport/ssh_netcat_helper.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     elif args.command == "send":
         dataset = zfs.get_object(args.dataset)
 
-        flags = []
+        flags = [libzfs.SendFlag.PROPS]
         if args.recursive:
             flags.append(libzfs.SendFlag.REPLICATE)
         if args.dedup:

--- a/zettarepl/transport/zfscli/__init__.py
+++ b/zettarepl/transport/zfscli/__init__.py
@@ -8,7 +8,7 @@ __all__ = ["zfs_send", "zfs_recv", "get_receive_resume_token"]
 
 def zfs_send(source_dataset: str, snapshot: str, recursive: bool, incremental_base: str, receive_resume_token: str,
              dedup: bool, large_block: bool, embed: bool, compressed: bool, report_progress=False):
-    send = ["zfs", "send"]
+    send = ["zfs", "send", "-p"]
 
     if recursive:
         send.append("-R")


### PR DESCRIPTION
Redmine issue: https://redmine.ixsystems.com/issues/73605

Legacy replication had following in it's code:

```
    cmd = ['/sbin/zfs', 'send', '-V']

    # -p switch will send properties for whole dataset, including snapshots
    # which will result in stale snapshots being delete as well
    if followdelete:
        cmd.append('-p')
```

So it was designed to always send properties and there was no demand for disabling this behavior.

`which will result in stale snapshots being delete as well` - this was not confirmed. Redmine issue is https://redmine.ixsystems.com/issues/12692 and github commit is freenas/freenas@3cade0b4061bdafce5abbb9f33893ec0e7bc59b3

```
root@freenas[~]# zfs list -t snapshot
NAME                                                             USED  AVAIL  REFER  MOUNTPOINT
data/dst@snap-1                                                     0      -    88K  -
data/dst@snap-2                                                     0      -    88K  -
data/dst@snap-3                                                     0      -    88K  -
data/dst@snap-4                                                     0      -    88K  -
data/dst@snap-5                                                     0      -    88K  -
data/src@snap-3                                                     0      -    88K  -
data/src@snap-4                                                     0      -    88K  -
data/src@snap-5                                                     0      -    88K  -
data/src@snap-6                                                     0      -    88K  -
root@freenas[~]# zfs send -p -i data/src@snap-5 data/src@snap-6 | zfs recv data/dst
root@freenas[~]# zfs list -t snapshot                                              
NAME                                                             USED  AVAIL  REFER  MOUNTPOINT
data/dst@snap-1                                                     0      -    88K  -
data/dst@snap-2                                                     0      -    88K  -
data/dst@snap-3                                                     0      -    88K  -
data/dst@snap-4                                                     0      -    88K  -
data/dst@snap-5                                                     0      -    88K  -
data/dst@snap-6                                                     0      -    88K  -
data/src@snap-3                                                     0      -    88K  -
data/src@snap-4                                                     0      -    88K  -
data/src@snap-5                                                     0      -    88K  -
data/src@snap-6                                                     0      -    88K  -
```
`data/dst@snap-1` and `data/dst@snap-2` were not deleted despite I've used `-p`. Can you by any chance recall what was happening?