### PR TITLE
Fix replication not being stopped properly when killed by replication monitor

### DIFF
--- a/integration-tests/transport/test_local_async_exec_stop.py
+++ b/integration-tests/transport/test_local_async_exec_stop.py
@@ -1,0 +1,27 @@
+# -*- coding=utf-8 -*-
+import subprocess
+import time
+
+from zettarepl.transport.local import LocalShell
+from zettarepl.utils.shlex import pipe
+
+
+def test__local_async_exec_stop():
+    def assert_marker_count(count):
+        assert int(subprocess.check_output(
+            "ps axw | grep ZETTAREPL_TEST_MARKER_1 | grep -v grep | wc -l", shell=True, encoding="utf-8",
+        ).strip()) == count
+
+    assert_marker_count(0)
+
+    local_shell = LocalShell()
+    exec = local_shell.exec_async(pipe(["python", "-c", "'ZETTAREPL_TEST_MARKER_1'; import time; time.sleep(60)"],
+                                       ["python", "-c", "'ZETTAREPL_TEST_MARKER_1'; import time; time.sleep(60)"]))
+
+    time.sleep(2)
+    assert_marker_count(6)
+
+    exec.stop()
+
+    time.sleep(1)
+    assert_marker_count(0)

--- a/tests/replication/test_monitor.py
+++ b/tests/replication/test_monitor.py
@@ -15,7 +15,7 @@ def test__replication_monitor__ok():
             event = Mock()
             event.wait.side_effect = [False, False, False, False, False, False, True]
             Event.return_value = event
-            assert ReplicationMonitor(Mock(), Mock()).run() == True
+            assert ReplicationMonitor(Mock(), Mock(), 60.0, 5).run() == True
 
 
 def test__replication_monitor__not_ok():
@@ -28,4 +28,4 @@ def test__replication_monitor__not_ok():
             event = Mock()
             event.wait.side_effect = [False, False, False, False, False, False, False, True]
             Event.return_value = event
-            assert ReplicationMonitor(Mock(), Mock()).run() == False
+            assert ReplicationMonitor(Mock(), Mock(), 60.0, 5).run() == False

--- a/zettarepl/replication/monitor.py
+++ b/zettarepl/replication/monitor.py
@@ -11,7 +11,7 @@ __all__ = ["ReplicationMonitor"]
 
 
 class ReplicationMonitor:
-    def __init__(self, shell, dataset, poll_interval=60.0, fail_on_repeat_count=5):
+    def __init__(self, shell, dataset, poll_interval=60.0, fail_on_repeat_count=60):
         self.shell = shell
         self.dataset = dataset
         self.poll_interval = poll_interval
@@ -23,8 +23,10 @@ class ReplicationMonitor:
         receive_resume_tokens = deque([], self.fail_on_repeat_count)
         while not self.stop_event.wait(self.poll_interval):
             receive_resume_tokens.append(get_receive_resume_token(self.shell, self.dataset))
-            logger.debug(f"receive_resume_tokens: %r", receive_resume_tokens)
-            if len(receive_resume_tokens) == self.fail_on_repeat_count and len(set(receive_resume_tokens)) == 1:
+            token_count = len(receive_resume_tokens)
+            unique_count = len(set(receive_resume_tokens))
+            logger.debug(f"receive_resume_tokens: count=%d, unique=%d", token_count, unique_count)
+            if token_count == self.fail_on_repeat_count and unique_count == 1:
                 return False
 
         return True


### PR DESCRIPTION
Support were talking about weird replication bug when zfs send | zfs recv just hang. They've used `pipewatcher` utility to monitor this, now we monitor changing of receive_resume_token and stop replication if it does not change within N minutes. I was able to catch this bug on my personal system: I've successfully transferred about 5T of snapshots with zettarepl, but one dataset just keeps hanging (some data is being transferred successfully before the hang though so this process will finish eventually). It happens on recent zfsonlinux.