### PR TITLE
Fix killing healthy replication when receive_resume_token does not work

### DIFF
--- a/zettarepl/replication/monitor.py
+++ b/zettarepl/replication/monitor.py
@@ -11,7 +11,7 @@ __all__ = ["ReplicationMonitor"]
 
 
 class ReplicationMonitor:
-    def __init__(self, shell, dataset, poll_interval=60.0, fail_on_repeat_count=60):
+    def __init__(self, shell, dataset, poll_interval=600.0, fail_on_repeat_count=6):
         self.shell = shell
         self.dataset = dataset
         self.poll_interval = poll_interval
@@ -26,7 +26,7 @@ class ReplicationMonitor:
             token_count = len(receive_resume_tokens)
             unique_count = len(set(receive_resume_tokens))
             logger.debug(f"receive_resume_tokens: count=%d, unique=%d", token_count, unique_count)
-            if token_count == self.fail_on_repeat_count and unique_count == 1:
+            if token_count == self.fail_on_repeat_count and unique_count == 1 and receive_resume_tokens[0] is not None:
                 return False
 
         return True


### PR DESCRIPTION
We have an evidence of a replication where receive_resume_tokens stays unset
during the send/receive; however, replication finishes successfully after
some time. Pool is healthy and upgraded.